### PR TITLE
Describe role more precisely

### DIFF
--- a/src/app/app.css
+++ b/src/app/app.css
@@ -674,56 +674,6 @@ h2{
   transform: rotate(180deg);
 }
 
-.msix-cta{
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  flex-wrap: wrap;
-  gap: 16px 24px;
-  max-width: 600px;
-  margin: 36px 0 36px auto;
-  padding: 22px 26px;
-  border-radius: 12px;
-  background: linear-gradient(135deg, var(--accent), var(--accent-hover));
-  color: #fff;
-  box-shadow: 0 6px 20px var(--polaroid-frame-shadow);
-}
-
-.msix-cta-body{
-  flex: 1 1 280px;
-}
-
-.msix-cta-title{
-  margin: 0 0 6px 0;
-  font-size: 16pt;
-  font-weight: 600;
-}
-
-.msix-cta-text{
-  margin: 0;
-  font-size: 11pt;
-  line-height: 1.4;
-  opacity: .95;
-}
-
-.msix-cta-btn,
-.msix-cta-btn:visited{
-  flex: 0 0 auto;
-  padding: 9px 18px;
-  border-radius: 6px;
-  background-color: #fff;
-  color: var(--accent);
-  border: 1px solid #fff;
-  font-weight: 600;
-  white-space: nowrap;
-  text-decoration: none;
-  transition: background-color .2s ease;
-}
-
-.msix-cta-btn:hover{
-  background-color: rgba(255, 255, 255, .85);
-}
-
 .small-projects{
   list-style: none;
   margin: 0;

--- a/src/app/welcome/welcome.tsx
+++ b/src/app/welcome/welcome.tsx
@@ -127,8 +127,8 @@ const EXPERIENCE = [
     role_de: "Teamleitung Softwareentwicklung",
     org_en: "gb&t Gebäudebestand und Technik",
     org_de: "gb&t Gebäudebestand und Technik",
-    desc_en: "Technical roadmap and architecture of telani; on-device AI (ONNX, semantic search), open-sourcing core libraries, and mentoring.",
-    desc_de: "Technische Roadmap und Architektur von telani; lokale KI (ONNX, Semantic Search), Open-Sourcing von Kern-Bibliotheken und Mentoring.",
+    desc_en: "Product direction, roadmap, and architecture of telani; on-device AI (ONNX, semantic search), open-sourcing core libraries, and mentoring.",
+    desc_de: "Produktausrichtung, Roadmap und Architektur von telani; lokale KI (ONNX, Semantic Search), Open-Sourcing von Kern-Bibliotheken und Mentoring.",
   },
   {
     period_en: "2022 – 2026",
@@ -255,19 +255,6 @@ export function Welcome({lang}: {lang: string}) {
           <span className="exp-more-chevron" aria-hidden="true">&#9662;</span>
         </label>
       </div>
-      <aside className="msix-cta">
-        <div className="msix-cta-body">
-          <h3 className="msix-cta-title">MSIX Consulting</h3>
-          <p className="msix-cta-text">
-            {lang === "en"
-              ? "Need help packaging your app with MSIX? I'm among the most experienced MSIX packaging experts in the world — let's talk."
-              : "Brauchen Sie Hilfe beim Verpacken Ihrer App mit MSIX? Ich gehöre zu den erfahrensten MSIX-Packaging-Experten weltweit — sprechen wir."}
-          </p>
-        </div>
-        <a className="msix-cta-btn" href="mailto:marvin+msix@server-fish.de?subject=MSIX%20Consulting">
-          {lang === "en" ? "Get in touch" : "Kontakt aufnehmen"}
-        </a>
-      </aside>
       <h2>{lang === "en" ? "Projects" : "Projekte"}</h2>
       <div className="row">
         {PROJECTS.map((p) => (

--- a/src/app/welcome/xaml.tsx
+++ b/src/app/welcome/xaml.tsx
@@ -165,12 +165,6 @@ export function XamlDoc({ lang, role, tagline, projects, skills, experience, sma
         ))}
         <Close n={3} name="ItemsControl" />
 
-        <Cm n={3} text="MSIX Consulting" />
-        <Open n={3} name="Border" attrs={[["Style", "{StaticResource AccentBanner}"]]} />
-        <Self n={4} name="TextBlock" attrs={[["Text", "MSIX Consulting"], ["FontWeight", "SemiBold"]]} />
-        <Self n={4} name="Button" attrs={[["Content", t("Get in touch", "Kontakt aufnehmen")]]} />
-        <Close n={3} name="Border" />
-
         <Cm n={3} text={t("Projects", "Projekte")} />
         <Open n={3} name="ItemsControl" attrs={[["Header", t("Projects", "Projekte")]]} />
         {projects.map((p, i) => (


### PR DESCRIPTION
- Update the wording of the 2026 experience entry (English and German).
- Remove the MSIX consulting call-to-action: the section markup, its representation in the XAML block, and the now-unused `.msix-cta*` styles.